### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "michaloo/wp-cli-environmentalize",
     "description": "Makes wp-config to load settings from ENV variables.",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/michaloo/wp-cli-environmentalize",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
